### PR TITLE
kernel: fix uart_asm_print call to debug()

### DIFF
--- a/src/kernel/arm-v-8/asm/macros.S
+++ b/src/kernel/arm-v-8/asm/macros.S
@@ -26,6 +26,7 @@
 
 //print a formatted string to the mini uart
 .macro uart_asm_print string
-    adr x0, \string
+    ldr x0, =0x2
+    adr x1, \string
     b debug
 .endm


### PR DESCRIPTION
The `debug` function expects a UART device selector as it's first argument. This PR passes that argument and sets it to `DBG_BOTH` from `src/lib/debug/debug.h`

**Testing**
* Manually confirmed the `Installed IRQ's\n` message from `irq_init()` is printed to stdout on kernel startup