### PR TITLE
[fix] boot.S: start OS in EL1 instead of EL2/3

### DIFF
--- a/src/kernel/arm-v-8/asm/sys_ctrl.S
+++ b/src/kernel/arm-v-8/asm/sys_ctrl.S
@@ -1,7 +1,7 @@
 /*
  *   This file is part of an AArch64 hobbyist OS for the Raspberry Pi 3 B+ called GENADEV_OS 
  *   Everything is openly developed on github: https://github.com/GENADEV/GENADEV_OS
- *   Copyright (C) 2021  Yves Vollmeier and Tim Thompson
+ *   Copyright (C) 2021  Yves Vollmeier, Tim Thompson and Michael Buch
  *
  *    This program is free software: you can redistribute it and/or modify
  *    it under the terms of the GNU General Public License as published by
@@ -19,7 +19,7 @@
  */
 
 enable_instruction_caching:
-    mrs x0, sctlr_el2
+    mrs x0, sctlr_el1
     orr x0, x0, #(1 << 12)
-    msr sctlr_el2, x0
+    msr sctlr_el1, x0
     ret

--- a/src/kernel/boot.S
+++ b/src/kernel/boot.S
@@ -1,7 +1,7 @@
 /*
- *   This file is part of an AArch64 hobbyist OS for the Raspberry Pi 3 B+ called GENADEV_OS 
+ *   This file is part of an AArch64 hobbyist OS for the Raspberry Pi 3 B+ called GENADEV_OS
  *   Everything is openly developed on github: https://github.com/GENADEV/GENADEV_OS
- *   Copyright (C) 2021  Yves Vollmeier and Tim Thompson
+ *   Copyright (C) 2021  Yves Vollmeier, Tim Thompson and Michael Buch
  *
  *    This program is free software: you can redistribute it and/or modify
  *    it under the terms of the GNU General Public License as published by
@@ -25,36 +25,63 @@
 
 .global _start
 _start:
-	//For now all but the primary core will be suspended
-	mrs x0, mpidr_el1	         //Multiprocessor Affinity Register
-	and x0, x0, #0xFF  		 //Lower 8 bits indicate the core no.
-	cbz x0, 2f			 //Is the Core ID == 0? (Main core)
-	b 1f				 //Stop the core
+    /* For now all but the primary core will be suspended */
+    mrs x0, mpidr_el1   // Multiprocessor Affinity Register
+    and x0, x0, #0xFF   // Lower 8 bits indicate the core no.
+    cbz x0, drop_to_el1 // Is the Core ID == 0? (Main core)
+    b hang              // Stop the core
 
-	//Every core that comes here != Core no. 0x0
-	1:
-		b 1b
+drop_to_el2:
+    // If we are already at EL2 (e.g., when running in QEMU),
+    // skip this step
+    mrs x0, CurrentEL
+    cmp x0, #(2 << 2)
+    b.eq drop_to_el1
 
-	//Main core is the only thing executing useful code from here on
-	2:
-		//Setup stack
-		ldr x1, =[0x80000]
-		mov sp, x1
+    mov x0, #0x5b1        // RW=1, HCE=1, SMD=1, RES=1, NS=1
+    msr scr_el3, x0
 
-		bl bss_zero 	//Zero out bss
-		bl main		//Kernel entry point
+    mov x0, #0x3c9        // D=1, A=1, I=1, F=1 M=EL2h
+    msr spsr_el3, x0
 
-	3:
-		b 3b
+    adr x0, drop_to_el1
+    msr elr_el3, x0
+    eret
+
+drop_to_el1:
+    ldr x0, =[0x80000]
+    msr sp_el1, x0
+
+    mov x1, #(1 << 31)    // Set execution state to AArch64
+    orr x1, x1, #(1 << 1) // SWIO
+    msr hcr_el2, x1
+
+    mov x1, #0x3c4        // D=1, A=1, I=1, F=1 M=EL1t
+    msr spsr_el2, x1
+
+    mov x3, #0x3000000    // Disable floating-point, SVE
+    msr cpacr_el1, x1
+
+    adr x1, el1_entry
+    msr elr_el2, x1
+    eret
+
+el1_entry:
+    bl bss_zero
+    bl main
+    b hang
 
 bss_zero:
     //Get size of bss section
-    ldr x0, =bss_begin
-    ldr x1, =bss_end
-    sub x3, x0, x1
+    mov sp, x0
+    adr x0, bss_begin
+    adr x1, bss_end
+    sub x1, x1, x0
+    2:
+        str xzr, [x0], #8
+        subs x1, x1, #8
+        b.gt 2b
+    ret
 
-    1:
-        sub x3, x1, x0      //Decrement the counter which specifies when the bss section is all zero
-        str xzr, [x0], #8   //clear out a section of bss data in byte sized chunks
-        bgt 1b		    //goto 1 if x3 > 0x0
-	ret
+hang:
+    b hang

--- a/src/kernel/boot.S
+++ b/src/kernel/boot.S
@@ -59,9 +59,6 @@ drop_to_el1:
     mov x1, #0x3c4        // D=1, A=1, I=1, F=1 M=EL1t
     msr spsr_el2, x1
 
-    mov x3, #0x3000000    // Disable floating-point, SVE
-    msr cpacr_el1, x1
-
     adr x1, el1_entry
     msr elr_el2, x1
     eret
@@ -77,10 +74,10 @@ bss_zero:
     adr x0, bss_begin
     adr x1, bss_end
     sub x1, x1, x0
-    2:
+    1:
         str xzr, [x0], #8
         subs x1, x1, #8
-        b.gt 2b
+        b.gt 1b
     ret
 
 hang:

--- a/src/kernel/boot.S
+++ b/src/kernel/boot.S
@@ -59,7 +59,7 @@ drop_to_el1:
     mov x1, #0x3c4        // D=1, A=1, I=1, F=1 M=EL1t
     msr spsr_el2, x1
 
-    mov x3, #(3 << 20)    // Disable floating-point, SVE
+    mov x1, #(3 << 20)    // Disable floating-point, SVE
     msr cpacr_el1, x1
 
     adr x1, el1_entry

--- a/src/kernel/boot.S
+++ b/src/kernel/boot.S
@@ -59,6 +59,9 @@ drop_to_el1:
     mov x1, #0x3c4        // D=1, A=1, I=1, F=1 M=EL1t
     msr spsr_el2, x1
 
+    mov x3, #(3 << 20)    // Disable floating-point, SVE
+    msr cpacr_el1, x1
+
     adr x1, el1_entry
     msr elr_el2, x1
     eret

--- a/src/kernel/boot.S
+++ b/src/kernel/boot.S
@@ -28,7 +28,7 @@ _start:
     /* For now all but the primary core will be suspended */
     mrs x0, mpidr_el1   // Multiprocessor Affinity Register
     and x0, x0, #0xFF   // Lower 8 bits indicate the core no.
-    cbz x0, drop_to_el1 // Is the Core ID == 0? (Main core)
+    cbz x0, drop_to_el2 // Is the Core ID == 0? (Main core)
     b hang              // Stop the core
 
 drop_to_el2:

--- a/src/kernel/int/ivt.S
+++ b/src/kernel/int/ivt.S
@@ -1,7 +1,7 @@
 /*
  *   This file is part of an AArch64 hobbyist OS for the Raspberry Pi 3 B+ called GENADEV_OS 
  *   Everything is openly developed on github: https://github.com/GENADEV/GENADEV_OS
- *   Copyright (C) 2021  Yves Vollmeier and Tim Thompson
+ *   Copyright (C) 2021  Yves Vollmeier, Tim Thompson and Michael Buch
  *
  *    This program is free software: you can redistribute it and/or modify
  *    it under the terms of the GNU General Public License as published by
@@ -126,7 +126,7 @@ undefined_irq_stub:
 .global irq_init
 irq_init:
     adr x0, ivt_desc //temp store
-    msr vbar_el2, x0 //load the ivt descriptor into the Vector-Base-Address-Register (Exception level 2)
+    msr vbar_el1, x0 //load the ivt descriptor into the Vector-Base-Address-Register (Exception level 2)
     uart_asm_print loaded_irq_msg
     ret
 

--- a/src/kernel/int/ivt.S
+++ b/src/kernel/int/ivt.S
@@ -126,7 +126,7 @@ undefined_irq_stub:
 .global irq_init
 irq_init:
     adr x0, ivt_desc //temp store
-    msr vbar_el1, x0 //load the ivt descriptor into the Vector-Base-Address-Register (Exception level 2)
+    msr vbar_el1, x0
     uart_asm_print loaded_irq_msg
     ret
 


### PR DESCRIPTION
**Summary**
Previously we booted into EL3 (on RPI3 hardware) or EL2 (on raspi3 QEMU). This PR makes sure we boot into EL1 regardless of where we start. EL1 is the lowest exception level at which the OS can operate and will be useful for coming interrupt implementation.

The previous boot sequence remains pretty much the same. We now just switch exception level before `bss_zero` and `main`.

**Testing**
* Manually verified that we can successfully boot without exceptions/system errors
* Test output:
```
qemu-system-aarch64 -M raspi3 -kernel kernel8.img -serial stdio -d int
Exception return from AArch64 EL2 to AArch64 EL1 PC 0x80068
<-- snipped -->
Current EL: 1
Installed IRQ's
=== CPU INFO ===
<-- snipped -->
```
Note in the above output that we (1) we took the exception state from EL2 to EL1, and (2) we have `CurrentEL == 1`
* Manually verified that if we try access a register in an EL > 1 after we jump into `main()`, the processors triggers an exception. Hence we also set up the IVT in EL1 instead of EL2