### PR TITLE
[new] Build system: add support for non-relative path include directives in lib/ and kernel/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,6 @@ build-headers: $(INCLUDE_DEST_FILES)
 
 $(INCLUDE_DEST)/%.h: src/%.h
 	@mkdir -p "$(@D)"
-	@echo Copying "$<" to "$@"
 	cp "$<" "$@"
 
 run: run_uart0

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -18,19 +18,19 @@
 */
 
 
-#include "arm-v-8/mb/mailbox.h"
-#include "arm-v-8/genadev_os.h"
-#include "arm-v-8/cpu.h"
-#include "hardware/framebuffer/framebuffer.h"
-#include "hardware/uart/mini_uart.h"
-#include "hardware/uart/uart0.h"
-#include "int/irq.h"
-#include "../lib/debug/debug.h"
-#include "../lib/stdio/stdio.h"
-#include "../lib/string/string.h"
-#include "panic/panic.h"
-#include "mm/vmm.h"
-#include "smp/spinlock.h"
+#include <kernel/arm-v-8/mb/mailbox.h>
+#include <kernel/arm-v-8/genadev_os.h>
+#include <kernel/arm-v-8/cpu.h>
+#include <kernel/hardware/framebuffer/framebuffer.h>
+#include <kernel/hardware/uart/mini_uart.h>
+#include <kernel/hardware/uart/uart0.h>
+#include <kernel/int/irq.h>
+#include <lib/debug/debug.h>
+#include <lib/stdio/stdio.h>
+#include <lib/string/string.h>
+#include <kernel/panic/panic.h>
+#include <kernel/mm/vmm.h>
+#include <kernel/smp/spinlock.h>
 
 void main()
 {

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -12,7 +12,7 @@
     GNU General Public License for more details.
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
-     
+
     Authors: The GENADEV_OS Founder Yves Vollmeier <https://github.com/Tix3Dev> and the lead developer Tim Thompson <https://github.com/V01D-NULL>
 	Contributers: All of the GENADEV_OS Contributers (tysm ^^) (Do not edit this section)
 */

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -23,13 +23,15 @@
 #include <kernel/hardware/framebuffer/framebuffer.h>
 #include <kernel/hardware/uart/mini_uart.h>
 #include <kernel/hardware/uart/uart0.h>
+#include <kernel/hardware/timer/timer.h>
 #include <kernel/int/irq.h>
-#include <lib/debug/debug.h>
-#include <lib/stdio/stdio.h>
-#include <lib/string/string.h>
 #include <kernel/panic/panic.h>
 #include <kernel/mm/vmm.h>
 #include <kernel/smp/spinlock.h>
+#include <lib/assert.h>
+#include <lib/debug/debug.h>
+#include <lib/stdio/stdio.h>
+#include <lib/string/string.h>
 
 void main()
 {


### PR DESCRIPTION
**Summary**
After this PR one can include using non-relative paths. E.g.,:
```
#include "../../lib/debug/debug.h"
```

becomes

```
#include <lib/debug/debug.h>
```

As an example this PR applied the non-relative includes to `kernel.c`.

**Technical description**
The approach taken in this PR is to simply `find` all header files under `src/` recursively and `cp` them (including the base-path) into the build directory. The new `include/` tree under `build/` is then added as an include path to the compile command, i.e., `gcc -Ibuild/include/ ...`