### PR TITLE
[new] Build system: add support for non-relative path include directives in lib/ and kernel/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ $(TARGET_FINAL): $(OBJ)
 	$(OBJCPY) $(BUILD)/$(TARGET_ELF) -O binary $@
 
 clean:
-	@rm -f $(OBJ) $(TARGET_ELF) $(TARGET_FINAL)
+	rm -f $(OBJ) $(TARGET_ELF) $(TARGET_FINAL)
 
 format:
 	astyle --mode=c -nA1TfpxgHxbxjxpS $(C_FILES)

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,6 @@ build-headers: $(INCLUDE_DEST_FILES)
 
 $(INCLUDE_DEST)/%.h: src/%.h
 	@mkdir -p "$(@D)"
-	@echo Copying "$<" to "$@"
 	cp "$<" "$@"
 
 run: run_uart0

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,9 @@ OBJCPY	= $(ARCH)-objcopy
 
 QEMU_AARCH64 = qemu-system-aarch64
 
-CC_OPT			= -mno-outline-atomics -fno-omit-frame-pointer -mcpu=cortex-a53 -nostdlib -ffreestanding -std=gnu99 -mgeneral-regs-only -O2 -c
+INCLUDEDIR=src
+
+CC_OPT			= -mno-outline-atomics -fno-omit-frame-pointer -mcpu=cortex-a53 -nostdlib -ffreestanding -std=gnu99 -mgeneral-regs-only -O2 -c -I$(INCLUDEDIR)
 TARGET_ELF		= kernel8.elf
 TARGET_FINAL	= kernel8.img
 
@@ -41,11 +43,8 @@ AS_OBJ	= $(AS_FILES:.S=.o)
 OBJ		= $(AS_OBJ) $(C_OBJ)
 
 BUILD = build
-INCLUDE_FILES=$(shell find src/ -type f -name '*.h')
-INCLUDE_DEST=$(BUILD)/include
-INCLUDE_DEST_FILES=$(patsubst src/%.h, $(INCLUDE_DEST)/%.h, $(INCLUDE_FILES))
 
-all: build-headers $(TARGET_FINAL)
+all: $(TARGET_FINAL)
 	@printf "DONE\n";
 
 setup: $(GNU_ARM_CC_TARBALL)
@@ -53,13 +52,6 @@ setup: $(GNU_ARM_CC_TARBALL)
 	@tar -xf $^ -C gnu-arm/
 	@printf "OK\tExtracted tarball archive\n";
 	@printf "Please install the libncurses5 package using your package manager (package name may vary based on your distro, this package name is derived from an apt package manager)\n";
-
-.PHONY: build-headers
-build-headers: $(INCLUDE_DEST_FILES)
-
-$(INCLUDE_DEST)/%.h: src/%.h
-	@mkdir -p "$(@D)"
-	cp "$<" "$@"
 
 run: run_uart0
 
@@ -77,7 +69,6 @@ $(TARGET_FINAL): $(OBJ)
 
 clean:
 	@rm -f $(OBJ) $(TARGET_ELF) $(TARGET_FINAL)
-	@rm -rf $(INCLUDE_DEST)
 
 format:
 	astyle --mode=c -nA1TfpxgHxbxjxpS $(C_FILES)
@@ -88,4 +79,4 @@ format:
 
 %.o: %.c
 	@printf " CC\t$<\n";
-	$(CC) -I$(INCLUDE_DEST) $(CC_OPT) -c $< -o $@
+	$(CC) $(CC_OPT) -c $< -o $@

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -18,19 +18,19 @@
 */
 
 
-#include "arm-v-8/mb/mailbox.h"
-#include "arm-v-8/genadev_os.h"
-#include "arm-v-8/cpu.h"
-#include "hardware/framebuffer/framebuffer.h"
-#include "hardware/uart/mini_uart.h"
-#include "hardware/uart/uart0.h"
-#include "int/irq.h"
-#include "../lib/debug/debug.h"
-#include "../lib/stdio/stdio.h"
-#include "../lib/string/string.h"
-#include "panic/panic.h"
-#include "mm/vmm.h"
-#include "smp/spinlock.h"
+#include <kernel/arm-v-8/mb/mailbox.h>
+#include <kernel/arm-v-8/genadev_os.h>
+#include <kernel/arm-v-8/cpu.h>
+#include <kernel/hardware/framebuffer/framebuffer.h>
+#include <kernel/hardware/uart/mini_uart.h>
+#include <kernel/hardware/uart/uart0.h>
+#include <kernel/int/irq.h>
+#include <lib/debug/debug.h>
+#include <lib/stdio/stdio.h>
+#include <lib/string/string.h>
+#include <kernel/panic/panic.h>
+#include <kernel/mm/vmm.h>
+#include <kernel/smp/spinlock.h>
 
 void main()
 {

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -12,7 +12,7 @@
     GNU General Public License for more details.
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
-     
+
     Authors: The GENADEV_OS Founder Yves Vollmeier <https://github.com/Tix3Dev> and the lead developer Tim Thompson <https://github.com/V01D-NULL>
 	Contributers: All of the GENADEV_OS Contributers (tysm ^^) (Do not edit this section)
 */

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -23,13 +23,15 @@
 #include <kernel/hardware/framebuffer/framebuffer.h>
 #include <kernel/hardware/uart/mini_uart.h>
 #include <kernel/hardware/uart/uart0.h>
+#include <kernel/hardware/timer/timer.h>
 #include <kernel/int/irq.h>
-#include <lib/debug/debug.h>
-#include <lib/stdio/stdio.h>
-#include <lib/string/string.h>
 #include <kernel/panic/panic.h>
 #include <kernel/mm/vmm.h>
 #include <kernel/smp/spinlock.h>
+#include <lib/assert.h>
+#include <lib/debug/debug.h>
+#include <lib/stdio/stdio.h>
+#include <lib/string/string.h>
 
 void main()
 {


### PR DESCRIPTION
**Summary**
After this PR one can include using non-relative paths. E.g.,:
```
#include "../../lib/debug/debug.h"
```

becomes

```
#include <lib/debug/debug.h>
```

As an example this PR applied the non-relative includes to `kernel.c`.
 
This is a follwup to [#5](https://github.com/GENADEV/GENADEV_OS/pull/5)